### PR TITLE
FilterData methods are now async

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -32,16 +32,18 @@ class FilterData {
         return this._params;
     }
 
-    resolve(response) {
-        this._resolve(response);
+    async resolve(response) {
+        return this._resolve(response);
     }
 
-    reject(err) {
-        this._reject(err);
+    async reject(err) {
+        return this._reject(err);
     }
 
-    on_completed(func) {
-        this._on_completed && this._on_completed(func);
+    async on_completed(func) {
+        if (this._on_completed) {
+            return this._on_completed(func);
+        }
     }
 }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -98,21 +98,44 @@ class Schema {
             return;
         }
 
-
-        let is_resolved = false, is_rejected = false;
-        let resolve_response = undefined, reject_error = undefined;
-        const on_resolve = function (_response) {
-            is_resolved = true;
-            resolve_response = _response;
-        };
-        const on_reject = function (_err) {
-            is_rejected = true;
-            reject_error = _err;
-        };
-
         let callbacks = [];
         const register_callback = function (cb) {
             callbacks.push(cb);
+        };
+
+        let is_resolved = false, is_rejected = false;
+        let resolve_response = undefined, reject_error = undefined;
+        const on_resolve = async function (_response) {
+            if (is_resolved) {
+                throw new Error("on_resolve already called");
+            }
+
+            is_rejected = false;
+            is_resolved = true;
+            resolve_response = _response;
+
+            const cbs = callbacks.reverse();
+            callbacks = [];
+
+            for (let cb of cbs) {
+                await cb(null, _response, context);
+            }
+        };
+        const on_reject = async function (_err) {
+            if (is_rejected) {
+                throw new Error("on_reject already called");
+            }
+
+            is_resolved = false;
+            is_rejected = true;
+            reject_error = _err;
+
+            const cbs = callbacks.reverse();
+            callbacks = [];
+
+            for (let cb of cbs) {
+                await cb(_err, undefined, context);
+            }
         };
 
         for (let entry of nodeData.entries)  {
@@ -145,23 +168,16 @@ class Schema {
             });
 
             try {
-                on_resolve(await entry.func.apply(context, args));
+                await on_resolve(await entry.func.apply(context, args));
+                break;
             } catch (err) {
-                on_reject(err);
+                await on_reject(err);
             }
         }
 
         if (!is_resolved && !reject_error) {
             reject_error = new Error("No response");
         }
-
-        if (callbacks.length > 0) {
-            debug('Running callbacks for "%s" (%d)', path, callbacks.length);
-            for (let cb of callbacks) {
-                await cb(is_resolved ? null : reject_error, resolve_response, context);
-            }
-        }
-
 
         if (is_resolved) {
             return resolve_response;


### PR DESCRIPTION
Now throwing an exception when attempting to resolve or reject multiple times
Callbacks now executed in reverse order on each resolve/reject
Execution is now interrupted when resolved